### PR TITLE
Support deserializing from a reader reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Allow deserialization from a reader reference with trailing data
 * Serialize and deserialize tuples and tuple structs.
 * Allow deserialization from a borrowed `Value`.
 * Set supported Rust version to `1.36.0`. The MSRV is not guranteed due to dependencies being free to bump their version.

--- a/src/de.rs
+++ b/src/de.rs
@@ -27,6 +27,23 @@ where
     Ok(value)
 }
 
+/// Deserializes an instance of `T` from the bytes of an [`io::Read`] type, advancing the position of the reader to the end of the deserialized bytes
+///
+/// # Errors
+///
+/// Deserialization can fail if the data is not valid, if the data cannot cannot be deserialized
+/// into an instance of `T`, and other IO errors.
+#[cfg(feature = "std")]
+pub fn take_from_reader<'a, R, T>(r: &mut R) -> Result<T>
+where
+    R: io::Read,
+    T: de::Deserialize<'a>,
+{
+    let mut de = Deserializer::new(read::IoRead::new(r));
+    let value = T::deserialize(&mut de)?;
+    Ok(value)
+}
+
 /// Deserializes an instance of `T` from a slice of bytes.
 ///
 /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,3 +131,7 @@ pub use ser::{to_vec, Serializer};
 #[doc(inline)]
 #[cfg(feature = "std")]
 pub use de::from_reader;
+
+#[doc(inline)]
+#[cfg(feature = "std")]
+pub use de::take_from_reader;


### PR DESCRIPTION
Hello!
I really appreciate your library, and also your recent commits.
I needed a way to deserialize from a reader with trailing data, to implement [BEP 0009](https://www.bittorrent.org/beps/bep_0009.html)

The `data` message is a bencoded dictionary, with raw bytes appended to it.

This simple addition works like a charm.
